### PR TITLE
+: 支持指定子域名更新。

### DIFF
--- a/src/DDNS.Api/Models/DDNSConfig.cs
+++ b/src/DDNS.Api/Models/DDNSConfig.cs
@@ -14,6 +14,8 @@ namespace DDNS.Api.Models
 
         public string domain { get; set; }
 
+        public string RR { get; set; }
+
         public string ignoreRR { get; set; }
     }
 }

--- a/src/DDNS/Program.cs
+++ b/src/DDNS/Program.cs
@@ -57,10 +57,18 @@ namespace DDNS
         {
             var current_ip = IPHelper.CurrentIp();
             var records = domainRecord.GetRecords(dnsConfig.domain);
-            if (!string.IsNullOrEmpty(dnsConfig.ignoreRR.Trim()))
+            if (string.IsNullOrEmpty(dnsConfig.RR.Trim()))
             {
-                var igs = dnsConfig.ignoreRR.Trim().Split("|");
-                records = records.Where(x => x.Type == "A" && !igs.Contains(x.RR));
+                if (!string.IsNullOrEmpty(dnsConfig.ignoreRR.Trim()))
+                {
+                    var igs = dnsConfig.ignoreRR.Trim().Split("|");
+                    records = records.Where(x => x.Type == "A" && !igs.Contains(x.RR));
+                }
+            }
+            else
+            {
+                var rs = dnsConfig.RR.Trim().Split("|");
+                records = records.Where(x => x.Type == "A" && rs.Contains(x.RR));
             }
 
             if (!records.Any(x => x.Value != current_ip))

--- a/src/DDNS/appsettings.json
+++ b/src/DDNS/appsettings.json
@@ -19,7 +19,11 @@
     // 顶级域名
     "domain": "test.com",
 
+    // 需更新的RR值，|分割，等值匹配
+    "RR": "*.ar|br",
+
     // 不进行更新的RR值，|分割，等值匹配
+    // 如果同时配置RR、ignoreRR节点，则优先RR节点生效
     "ignoreRR": "*.sg|sg"
   }
 }


### PR DESCRIPTION
Hi SpringHgui,
首先，感谢您提供的这个工具。

当顶级域名下存在多个子域名时，希望可以指定更新某些域名，所以我在配置文件里新增了“RR”节点。
当用户同时配置了“RR”节点和“ignoreRR”节点时，为防止域名被大量更新，则优先使用“RR”节点数据。

变更过程中，我尽量保持代码样式与您一致。
希望您认可这些更改，这应该是一个广泛性需求。

Thanks SpringHgui.

Cheers,
-Lionden